### PR TITLE
Fix: Increase camera loading timeout and update message

### DIFF
--- a/src/components/CameraLoading.tsx
+++ b/src/components/CameraLoading.tsx
@@ -7,7 +7,7 @@ const CameraLoading = () => {
       <div className="text-center text-gray-400">
         <div className="w-8 h-8 mx-auto mb-2 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin"></div>
         <p className="text-sm">Loading camera...</p>
-        <p className="text-xs mt-1 opacity-75">This should only take a few seconds</p>
+        <p className="text-xs mt-1 opacity-75">This may take a few moments, especially on the first use or slower connections.</p>
       </div>
     </div>
   );

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -73,7 +73,7 @@ export const useCamera = ({ enabled, facingMode }: UseCameraProps) => {
         console.log('Camera loading timeout');
         setIsLoading(false);
         setError('Camera is taking too long to load. Please try again or check your camera settings.');
-      }, 8000);
+      }, 15000);
       
       // Stop existing stream
       if (stream) {


### PR DESCRIPTION
I've increased the camera loading timeout from 8 to 15 seconds in `useCamera.ts` to give the camera more time to initialize, potentially resolving issues where the camera appeared to load indefinitely.

I've also updated the loading message in `CameraLoading.tsx` to better manage your expectations regarding camera startup time.