### PR TITLE
Fix: Enable and correct Spanish real-time text highlighting

### DIFF
--- a/src/components/AIProcessor.tsx
+++ b/src/components/AIProcessor.tsx
@@ -165,30 +165,38 @@ class AIProcessor {
       }
 
       utterance.onstart = () => {
-        console.log('Speech synthesis started');
+        // console.log('Speech synthesis started'); // Original log, can be kept or removed based on general preference
         window.dispatchEvent(new CustomEvent('ai-speaking-start'));
       };
 
       utterance.onboundary = (event: SpeechSynthesisEvent) => {
-        console.log('Speech boundary:', event.charIndex, event.name); // event.name is usually empty string
+        // console.log(`[AIProcessor] onboundary: charIndex=${event.charIndex}, text="${utterance.text.substring(0, 50)}..."`);
         window.dispatchEvent(new CustomEvent('ai-speech-boundary', {
           detail: {
             charIndex: event.charIndex,
-            text: utterance.text // The full text of the utterance this event belongs to
+            text: utterance.text
           }
         }));
       };
 
       utterance.onend = () => {
-        console.log('Speech synthesis ended');
+        // console.log(`[AIProcessor] onend: Speech synthesis ended for text="${utterance.text.substring(0, 50)}..."`);
         window.dispatchEvent(new CustomEvent('ai-speaking-end'));
+        // Also ensure spokenCharIndex is set to full length on end
+        window.dispatchEvent(new CustomEvent('ai-speech-boundary', {
+          detail: {
+            charIndex: utterance.text.length, // Final charIndex
+            text: utterance.text
+          }
+        }));
       };
 
       utterance.onerror = (event) => {
-        console.error('Speech synthesis error:', event);
+        console.error('Speech synthesis error:', event); // Keeping this error log
         window.dispatchEvent(new CustomEvent('ai-speaking-end'));
       };
 
+      // console.log(`[AIProcessor] speakText: Attempting to speak. Language: ${utterance.lang || 'default'}, Text: "${text.substring(0, 50)}..."`);
       speechSynthesis.speak(utterance);
     }
   }

--- a/src/components/ChatDisplay.tsx
+++ b/src/components/ChatDisplay.tsx
@@ -63,14 +63,33 @@ const ChatDisplay: React.FC<ChatDisplayProps> = ({ messages }) => {
                 <div className="flex-1">
                   {message.type === 'assistant' ? (
                     isMobile && message.isTranslatable && message.translationKey ? (
-                      <>
-                        <div className="text-sm leading-relaxed font-semibold">
-                          EN: <HighlightedText text={i18n.t(message.translationKey, { lng: 'en' })} spokenCharIndex={message.spokenCharIndex || 0} />
-                        </div>
-                        <div className="text-sm leading-relaxed mt-1">
-                          ES: {i18n.t(message.translationKey, { lng: 'es' })} {/* Spanish shown plain */}
-                        </div>
-                      </>
+                      (() => {
+                        // message.text is assumed to be already in the current i18n.language
+                        // message.spokenCharIndex refers to message.text
+                        const currentTextLang = i18n.language.startsWith('es') ? 'es' : 'en';
+
+                        const englishText = i18n.t(message.translationKey!, { lng: 'en' });
+                        const spanishText = i18n.t(message.translationKey!, { lng: 'es' });
+
+                        return (
+                          <>
+                            <div className="text-sm leading-relaxed font-semibold">
+                              EN: {currentTextLang === 'en' ? (
+                                <HighlightedText text={englishText} spokenCharIndex={message.spokenCharIndex || 0} />
+                              ) : (
+                                englishText // English plain if Spanish is spoken/primary
+                              )}
+                            </div>
+                            <div className="text-sm leading-relaxed mt-1">
+                              ES: {currentTextLang === 'es' ? (
+                                <HighlightedText text={spanishText} spokenCharIndex={message.spokenCharIndex || 0} />
+                              ) : (
+                                spanishText // Spanish plain if English is spoken/primary
+                              )}
+                            </div>
+                          </>
+                        );
+                      })()
                     ) : (
                       <div className="text-sm leading-relaxed">
                         <HighlightedText text={message.text} spokenCharIndex={message.spokenCharIndex || 0} />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -56,16 +56,23 @@ const Index = () => {
     const handleSpeechBoundary = (event: Event) => {
       const customEvent = event as CustomEvent<{ charIndex: number; text: string }>;
       const { charIndex, text: utteranceText } = customEvent.detail;
+      // console.log(`[Index.tsx] handleSpeechBoundary: charIndex=${charIndex}, utteranceText="${utteranceText.substring(0, 50)}..."`);
 
-      setMessages(prevMessages =>
-        prevMessages.map(msg => {
-          // Identify the message that matches the utterance text.
+      setMessages(prevMessages => {
+        let matched = false;
+        const updatedMessages = prevMessages.map(msg => {
           if (msg.type === 'assistant' && msg.text === utteranceText) {
+            // console.log(`[Index.tsx] Matched message ID ${msg.id}. Updating spokenCharIndex to ${charIndex}. Old: ${msg.spokenCharIndex}`);
+            matched = true;
             return { ...msg, spokenCharIndex: charIndex };
           }
           return msg;
-        })
-      );
+        });
+        if (!matched) {
+          // console.warn(`[Index.tsx] No message matched utteranceText: "${utteranceText.substring(0, 50)}..."`);
+        }
+        return updatedMessages;
+      });
     };
 
     window.addEventListener('ai-speech-boundary', handleSpeechBoundary);


### PR DESCRIPTION
This commit addresses issues with karaoke-style text highlighting for Spanish language content:

1.  **ChatDisplay Bilingual Highlighting:**
    - Updated `ChatDisplay.tsx` to correctly apply `HighlightedText` to the Spanish version of translatable messages when Spanish is the active language and the message is displayed bilingually on mobile.
    - This ensures that if Spanish text is being spoken by TTS, it receives the synchronized highlighting, rather than defaulting to highlighting English only.

2.  **TTS `onend` Event Enhancement:**
    - Modified `AIProcessor.tsx` so that when a speech utterance ends (`onend` event), it dispatches a final `ai-speech-boundary` event with `charIndex` set to the full length of the text.
    - This ensures the entire spoken text segment becomes fully highlighted upon completion of speech, resolving potential issues where the last word might not get fully highlighted.

These changes should provide a more consistent and accurate real-time highlighting experience when Spanish is the active language for TTS.